### PR TITLE
update hashed-pallets dependencies to version 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "pallet-afloat"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4656,7 +4656,7 @@ dependencies = [
 [[package]]
 name = "pallet-bitcoin-vaults"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "pallet-confidential-docs"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "pallet-fruniques"
 version = "0.1.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "pallet-fund-admin"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "pallet-fund-admin-records"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4771,7 +4771,7 @@ dependencies = [
 [[package]]
 name = "pallet-gated-marketplace"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4862,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "pallet-mapped-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "pallet-rbac"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5003,7 +5003,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.3#a9f61c2aa2eaec4f5835e39e565985943645c9fb"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.4#d806af2b2027f07e30ea93b25a0770fd3181393b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -64,16 +64,16 @@ frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", b
 hex-literal = { version = "0.4.1", optional = true }
 
 # Hashed Dependencies
-pallet-template = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-fruniques = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-bitcoin-vaults = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-gated-marketplace = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-rbac = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-confidential-docs = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-fund-admin = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-afloat = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-mapped-assets = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
-pallet-fund-admin-records = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.3", default-features = false }
+pallet-template = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-fruniques = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-bitcoin-vaults = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-gated-marketplace = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-rbac = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-confidential-docs = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-fund-admin = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-afloat = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-mapped-assets = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
+pallet-fund-admin-records = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.4", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }


### PR DESCRIPTION
PR summary
- Updated the version of nine Hashed Pallets dependencies from 0.1.3 to 0.1.4
- Updated the versions of the following pallets in Cargo.lock: pallet-afloat, pallet-bitcoin-vaults, pallet-confidential-docs, pallet-fruniques, pallet-fund-admin, pallet-fund-admin-records, pallet-gated-marketplace, pallet-mapped-assets, pallet-rbac, pallet-template.