### PR TITLE
update hashed-pallets dependencies to version 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,7 +4574,7 @@ dependencies = [
 [[package]]
 name = "pallet-afloat"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4656,7 +4656,7 @@ dependencies = [
 [[package]]
 name = "pallet-bitcoin-vaults"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4711,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "pallet-confidential-docs"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4723,7 +4723,7 @@ dependencies = [
 [[package]]
 name = "pallet-fruniques"
 version = "0.1.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4740,7 +4740,7 @@ dependencies = [
 [[package]]
 name = "pallet-fund-admin"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "pallet-fund-admin-records"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4771,7 +4771,7 @@ dependencies = [
 [[package]]
 name = "pallet-gated-marketplace"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4862,7 +4862,7 @@ dependencies = [
 [[package]]
 name = "pallet-mapped-assets"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "pallet-rbac"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5003,7 +5003,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "4.0.0-dev"
-source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.5#7ec0bdff6a6ad68317ec593bb464c9df31455b89"
+source = "git+https://github.com/hashed-io/hashed-pallets?tag=0.1.6#fcaab50c8731bb2b61ed6b59e3e466e71cb5858a"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -64,16 +64,16 @@ frame-system-benchmarking = { git = "https://github.com/paritytech/substrate", b
 hex-literal = { version = "0.4.1", optional = true }
 
 # Hashed Dependencies
-pallet-template = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-fruniques = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-bitcoin-vaults = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-gated-marketplace = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-rbac = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-confidential-docs = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-fund-admin = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-afloat = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-mapped-assets = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
-pallet-fund-admin-records = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.5", default-features = false }
+pallet-template = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-fruniques = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-bitcoin-vaults = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-gated-marketplace = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-rbac = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-confidential-docs = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-fund-admin = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-afloat = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-mapped-assets = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
+pallet-fund-admin-records = { git = "https://github.com/hashed-io/hashed-pallets", tag = "0.1.6", default-features = false }
 
 [build-dependencies]
 substrate-wasm-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.40" }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -133,9 +133,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
 	// Chaos spec version
-	// spec_version: 154,
+	// spec_version: 154, // toggle this line for chaos specs only (deployment)
 	// Inova spec version
-	spec_version: 169,
+	spec_version: 169, // toggle this line for inova specs only (deployment)
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -133,9 +133,9 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
 	// Chaos spec version
-	spec_version: 154,
+	// spec_version: 154,
 	// Inova spec version
-	// spec_version: 168,
+	spec_version: 169,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
PR summary so far:

* Updated version of 10 pallets from 0.1.5 to 0.1.6.
* Changed `spec_version` from 168 to 169 for Inova specs.
* Commented out `spec_version` for Chaos specs.